### PR TITLE
Fix bug in pxa1088-dtbtool.c

### DIFF
--- a/pxa1088-dtbtool.c
+++ b/pxa1088-dtbtool.c
@@ -447,7 +447,7 @@ int main(int argc, char **argv)
     log_info("\nGenerating master DTB... ");
 
     out_fd = open(output_file, O_WRONLY|O_CREAT, S_IRUSR|S_IWUSR);
-    if (!(out_fd < 0)) {
+    if (out_fd < 0) {
         log_err("Cannot create '%s'\n", output_file);
         rc = RC_ERROR;
         goto cleanup;


### PR DESCRIPTION
The `open` return value is the file description or `-1` in case of error (http://man7.org/linux/man-pages/man2/open.2.html#RETURN_VALUE).

The condition here is wrong because if the file is created, the `out_fd ` value will be some positive integer number, hence the if check is wrong